### PR TITLE
Define error response schema in OpenAPI

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,10 +81,37 @@ paths:
                         d: [542.04, 52331224]
         "400":
           description: Bad request (invalid JSON or parameters)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                default:
+                  value:
+                    error: "Bad Request"
+                    detail: "Invalid parameters"
         "401":
           description: Authentication required for real-time data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                default:
+                  value:
+                    error: "Unauthorized"
+                    detail: "Authentication required"
         "500":
           description: TradingView server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                default:
+                  value:
+                    error: "Internal Server Error"
+                    detail: "Unexpected error occurred"
       security:
         - SessionCookieAuth: []
 
@@ -313,3 +340,12 @@ components:
           items:
             $ref: "#/components/schemas/ScreenerRow"
           description: List of screener rows corresponding to your columns
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      required: [error, detail]
+      properties:
+        error:
+          type: string
+        detail:
+          type: string


### PR DESCRIPTION
## Summary
- add `ErrorResponse` schema
- document sample error responses for `/[market]/scan`

## Testing
- `pytest -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3db0630832c923c314807712330