### PR TITLE
Fix YAML schema for validator

### DIFF
--- a/samples/numeric_indicator_api_sample.yaml
+++ b/samples/numeric_indicator_api_sample.yaml
@@ -204,7 +204,8 @@ components:
               items:
                 type: object
                 properties:
-                  type: string
+                  type:
+                    type: string
                   values:
                     type: string
         options:


### PR DESCRIPTION
## Summary
- fix indentation in numeric_indicator_api_sample.yaml to properly define `groups` schema

## Testing
- `python -m openapi_spec_validator samples/numeric_indicator_api_sample.yaml`
- `pytest -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6841616ff780832cbd7baeecb3007713