### PR TITLE
Add daily timeframe documentation

### DIFF
--- a/samples/numeric_indicator_api_sample.yaml
+++ b/samples/numeric_indicator_api_sample.yaml
@@ -215,7 +215,10 @@ components:
           items:
             type: string
           description: |
-            Names of technical indicators or other fields. Timeframe-supporting indicators use the syntax `INDICATOR|{tf}` where `tf` is one of the values listed in `x-timeframes`.
+            Names of technical indicators or other fields. Timeframe-supporting
+            indicators **must** include a timeframe suffix using the syntax
+            `INDICATOR|{tf}` (for example `rsi|1D` or `sma|60`). The `{tf}`
+            value must be one of the options listed in `x-timeframes`.
         filter:
           type: array
           items:
@@ -3902,5 +3905,6 @@ components:
     - '60' # 1 hour
     - '120' # 2 hours
     - '240' # 4 hours
+    - '1D' # daily
     - '1W' # weekly
     - '1M' # monthly


### PR DESCRIPTION
## Summary
- clarify timeframe usage in the YAML sample
- add the missing 1D timeframe to `x-timeframes`

## Testing
- `ruff format --check`
- `pytest -q tests/test_query.py::test_limit_and_offset -vv` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_684169200818832caf35f46493d7e9d7