### PR TITLE
Update SessionCookieAuth instructions

### DIFF
--- a/samples/numeric_indicator_api_sample.yaml
+++ b/samples/numeric_indicator_api_sample.yaml
@@ -87,7 +87,15 @@ components:
       type: apiKey
       in: cookie
       name: sessionid
-      description: TradingView authentication cookie used to obtain real-time data. Acquire it by POSTing to `/accounts/signin/`.
+      description: |
+        TradingView authentication cookie used to obtain real-time data.
+        See the README for ways to obtain `sessionid` either by copying it from
+        your browser cookies or by sending a login request to
+        `/accounts/signin/`.
+        Example:
+          ```python
+          cookies = {"sessionid": "<your-session-id>"}
+          ```
   parameters:
     MarketPath:
       name: market


### PR DESCRIPTION
## Summary
- clarify how to obtain `sessionid` from browser or login request in OpenAPI
- show cookie in example request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417d15b844832cbee675ff8d28a773