### PR TITLE
Add automated metainfo updater

### DIFF
--- a/.github/workflows/update_metainfo.yml
+++ b/.github/workflows/update_metainfo.yml
@@ -1,0 +1,37 @@
+name: Update Metainfo
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry install
+
+      - name: Update metainfo
+        run: poetry run python scripts/update_metainfo.py
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "chore: update metainfo" && git push
+          else
+            echo "No changes"
+          fi

--- a/README.md
+++ b/README.md
@@ -239,8 +239,10 @@ This library is also a wrapper that makes it easier to generate those verbose JS
 
 ## Robustness & Longevity
 
-This package is designed to be future-proof. There are no hard-coded values in the package, all fields/columns and markets are documented on the website, which is updated
-daily via a GitHub Actions script.
+This package is designed to be future-proof. There are no hard-coded values in the package.
+All fields/columns and markets are documented on the website. These files are refreshed
+nightly by the `update_metainfo.yml` workflow, which downloads the latest metadata from
+TradingView and regenerates the OpenAPI specs.
 
 ## How It Works
 

--- a/scripts/update_metainfo.py
+++ b/scripts/update_metainfo.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+from pathlib import Path
+
+import requests
+
+from tradingview_screener.query import HEADERS
+
+MARKETS_PATH = Path('data/markets.json')
+METAINFO_DIR = Path('data/metainfo')
+
+
+def main() -> None:
+    markets_data = json.loads(MARKETS_PATH.read_text())
+    markets = markets_data.get('countries', []) + markets_data.get('other', [])
+    METAINFO_DIR.mkdir(parents=True, exist_ok=True)
+    for market in markets:
+        url = f'https://scanner.tradingview.com/{market}/meta'
+        print(f'Downloading {url}')
+        resp = requests.get(url, headers=HEADERS)
+        resp.raise_for_status()
+        (METAINFO_DIR / f'{market}.json').write_text(resp.text)
+
+    subprocess.run(['python', 'scripts/generate_openapi.py'], check=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- script to pull TradingView market metadata and regenerate specs
- nightly GitHub Actions workflow to run the updater
- document metainfo automation in README

## Testing
- `poetry run ruff format scripts/update_metainfo.py`
- `poetry run ruff check scripts/update_metainfo.py --fix`
- `poetry run pyright scripts/update_metainfo.py`
- `poetry install --with dev`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420c3d4660832c8bb23a37761937a1