### PR TITLE
Fix metainfo endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import yaml
 from tradingview_screener.query import HEADERS
 
 MARKETS_URL = "https://scanner.tradingview.com/markets"
-META_URL = "https://scanner.tradingview.com/{market}/meta"
+META_URL = "https://scanner.tradingview.com/{market}/metainfo"
 OUTPUT_DIR = Path("openapi_generated")
 BASE_SPEC_PATH = Path("openapi.yaml")
 MARKETS_PATH = Path("data/markets.json")
@@ -26,7 +26,9 @@ def get_markets() -> List[str]:
         return data.get("countries", []) + data.get("other", [])
 
 def fetch_metainfo(market: str) -> List[dict]:
-    resp = requests.get(META_URL.format(market=market), headers=HEADERS, timeout=10)
+    resp = requests.post(
+        META_URL.format(market=market), json={}, headers=HEADERS, timeout=10
+    )
     resp.raise_for_status()
     return resp.json()
 

--- a/scripts/update_metainfo.py
+++ b/scripts/update_metainfo.py
@@ -15,13 +15,13 @@ def main() -> None:
     markets = markets_data.get('countries', []) + markets_data.get('other', [])
     METAINFO_DIR.mkdir(parents=True, exist_ok=True)
     for market in markets:
-        url = f'https://scanner.tradingview.com/{market}/meta'
+        url = f'https://scanner.tradingview.com/{market}/metainfo'
         print(f'Downloading {url}')
-        resp = requests.get(url, headers=HEADERS)
+        resp = requests.post(url, json={}, headers=HEADERS)
         resp.raise_for_status()
         (METAINFO_DIR / f'{market}.json').write_text(resp.text)
 
-    subprocess.run(['python', 'scripts/generate_openapi.py'], check=True)
+    subprocess.run(['python', 'scripts/gpt_openapi_generator.py'], check=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_update_metainfo.py
+++ b/tests/test_update_metainfo.py
@@ -20,8 +20,8 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
     call_order = []
 
-    def fake_get(url, headers=None):
-        call_order.append(('get', url))
+    def fake_post(url, json=None, headers=None):
+        call_order.append(('post', url))
 
         class Resp:
             def __init__(self, text):
@@ -32,7 +32,7 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
         return Resp(f'data for {url}')
 
-    monkeypatch.setattr(update_metainfo.requests, 'get', fake_get)
+    monkeypatch.setattr(update_metainfo.requests, 'post', fake_post)
 
     def fake_run(args, check=False):
         call_order.append(('run', args))
@@ -41,14 +41,14 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
     update_metainfo.main()
 
-    get_calls = [c for c in call_order if c[0] == 'get']
+    get_calls = [c for c in call_order if c[0] == 'post']
     run_calls = [c[1] for c in call_order if c[0] == 'run']
 
     assert len(get_calls) == len(markets)
     assert run_calls == [
         [
             'python',
-            'scripts/generate_openapi.py',
+            'scripts/gpt_openapi_generator.py',
         ]
     ]
     assert call_order[-1][0] == 'run'
@@ -56,4 +56,4 @@ def test_update_metainfo(monkeypatch, tmp_path):
     for market in markets:
         path = meta_dir / f'{market}.json'
         assert path.exists()
-        assert path.read_text() == f'data for https://scanner.tradingview.com/{market}/meta'
+        assert path.read_text() == f'data for https://scanner.tradingview.com/{market}/metainfo'


### PR DESCRIPTION
## Summary
- use `/metainfo` endpoint instead of outdated `/meta`
- call GPT OpenAPI generator in update_metainfo script
- adjust tests for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422f5c3b54832cbc9464ec9384998d