### PR TITLE
Add modular OpenAPI generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,103 +1,22 @@
-import json
-import copy
-from pathlib import Path
-from typing import List, Tuple
+from __future__ import annotations
 
-import requests
-import yaml
+from market_loader import get_markets
+from tv_api_parser import fetch_metainfo, group_fields
+from openapi_generator import generate_spec
 
-from tradingview_screener.query import HEADERS
-
-MARKETS_URL = "https://scanner.tradingview.com/markets"
-META_URL = "https://scanner.tradingview.com/{market}/metainfo"
-OUTPUT_DIR = Path("openapi_generated")
-BASE_SPEC_PATH = Path("openapi.yaml")
-MARKETS_PATH = Path("data/markets.json")
-
-def get_markets() -> List[str]:
-    """Return the list of available markets."""
-    try:
-        resp = requests.get(MARKETS_URL, headers=HEADERS, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
-        return data.get("countries", []) + data.get("other", [])
-    except Exception:
-        data = json.loads(MARKETS_PATH.read_text())
-        return data.get("countries", []) + data.get("other", [])
-
-def fetch_metainfo(market: str) -> List[dict]:
-    resp = requests.post(
-        META_URL.format(market=market), json={}, headers=HEADERS, timeout=10
-    )
-    resp.raise_for_status()
-    return resp.json()
-
-def group_fields(meta: List[dict]) -> Tuple[List[str], List[str], List[str]]:
-    columns = [item.get("n") for item in meta if item.get("n")]
-    no_tf = sorted({c for c in columns if "|" not in c})
-    tf_columns = [c for c in columns if "|" in c]
-    bases = sorted({c.split("|")[0] for c in tf_columns})
-    tfs = sorted({c.split("|")[1] for c in tf_columns})
-    return no_tf, bases, tfs
-
-def build_spec(market: str, base: dict, no_tf: List[str], with_tf: List[str], tfs: List[str]) -> dict:
-    spec = copy.deepcopy(base)
-    spec["info"]["title"] = f"TradingView Screener API — {market}"
-    spec.setdefault("info", {})
-    description = spec["info"].get("description", "")
-    spec["info"]["description"] = description + "\nCompatible with GPT Custom Actions."
-    # convert paths -> functions
-    if "paths" in spec:
-        path = "/{market}/scan"
-        if path in spec["paths"]:
-            op = spec["paths"][path]["post"]
-        else:
-            op = {}
-        spec.pop("paths")
-    else:
-        op = {}
-    parameters = op.get("requestBody", {}).get("content", {}).get("application/json", {}).get("schema", {"$ref": "#/components/schemas/QueryDict"})
-    responses = op.get("responses", {"200": {"description": "Screener results", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ScreenerDict"}}}}})
-    spec["functions"] = {
-        f"scan_{market}": {
-            "operationId": f"scan_{market}",
-            "summary": op.get("summary", "Scan TradingView market"),
-            "description": op.get("description", ""),
-            "parameters": parameters,
-            "responses": responses,
-        }
-    }
-    comp = spec.setdefault("components", {}).setdefault("schemas", {})
-    comp["NumericFieldNoTimeframe"] = {
-        "type": "string",
-        "enum": no_tf,
-    }
-    if with_tf and tfs:
-        pattern = f"^({'|'.join(with_tf)})\\|({'|'.join(tfs)})$"
-    else:
-        pattern = "^[A-Za-z0-9_.\\[\\]-]+\\|.*$"
-    comp["NumericFieldWithTimeframe"] = {
-        "type": "string",
-        "pattern": pattern,
-    }
-    spec["x-timeframes"] = tfs
-    return spec
 
 def main() -> None:
-    OUTPUT_DIR.mkdir(exist_ok=True)
-    base = yaml.safe_load(BASE_SPEC_PATH.read_text())
     markets = get_markets()
     for market in markets:
         try:
             meta = fetch_metainfo(market)
-        except Exception as e:
-            print(f"Failed to download metainfo for {market}: {e}")
+        except Exception as exc:
+            print(f'Failed to get metainfo for {market}: {exc}')
             continue
         no_tf, with_tf, tfs = group_fields(meta)
-        spec = build_spec(market, base, no_tf, with_tf, tfs)
-        out_path = OUTPUT_DIR / f"{market}.yaml"
-        out_path.write_text(yaml.safe_dump(spec, sort_keys=False, allow_unicode=True))
-        print(f"Generated {out_path}")
+        path = generate_spec(market, no_tf, with_tf, tfs)
+        print(f'Generated {path}')
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()

--- a/market_loader.py
+++ b/market_loader.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+from typing import List
+
+import requests
+
+from tradingview_screener.query import HEADERS
+
+MARKETS_URL = 'https://scanner.tradingview.com/markets'
+MARKETS_PATH = Path('data/markets.json')
+
+
+def get_markets() -> List[str]:
+    """Return available markets from TradingView or local cache."""
+    try:
+        resp = requests.get(MARKETS_URL, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get('countries', []) + data.get('other', [])
+    except Exception:
+        data = json.loads(MARKETS_PATH.read_text())
+        return data.get('countries', []) + data.get('other', [])

--- a/openapi_generator.py
+++ b/openapi_generator.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import List
+
+import yaml
+from openapi_spec_validator.shortcuts import validate_spec
+
+BASE_SPEC_PATH = Path('openapi.yaml')
+OUTPUT_DIR = Path('openapi_generated')
+
+
+def build_spec(
+    market: str, base: dict, no_tf: List[str], with_tf: List[str], tfs: List[str]
+) -> dict:
+    spec = copy.deepcopy(base)
+    info = spec.setdefault('info', {})
+    info['title'] = f'TradingView Screener API — {market}'
+    info['description'] = info.get('description', '') + '\nCompatible with GPT Custom Actions.'
+
+    op = {}
+    if 'paths' in spec:
+        template = '/{market}/scan'
+        if template in spec['paths']:
+            op = spec['paths'].pop(template)['post']
+        spec.pop('paths', None)
+
+    parameters = (
+        op.get('requestBody', {})
+        .get('content', {})
+        .get('application/json', {})
+        .get('schema', {'$ref': '#/components/schemas/QueryDict'})
+    )
+    responses = op.get(
+        'responses',
+        {
+            '200': {
+                'description': 'Screener results',
+                'content': {
+                    'application/json': {'schema': {'$ref': '#/components/schemas/ScreenerDict'}}
+                },
+            }
+        },
+    )
+    spec['functions'] = {
+        f'scan_{market}': {
+            'operationId': f'scan_{market}',
+            'summary': op.get('summary', 'Scan TradingView market'),
+            'description': op.get('description', ''),
+            'parameters': parameters,
+            'responses': responses,
+        }
+    }
+
+    comp = spec.setdefault('components', {}).setdefault('schemas', {})
+    comp['IndicatorWithoutTimeframe'] = {
+        'type': 'string',
+        'enum': no_tf,
+        'examples': no_tf[:1],
+    }
+    combos = [f'{b}|{tf}' for b in with_tf for tf in tfs]
+    comp['IndicatorWithTimeframe'] = {
+        'type': 'string',
+        'enum': combos,
+        'examples': combos[:1],
+    }
+
+    qdict = comp.get('QueryDict')
+    if qdict:
+        cols = qdict.get('properties', {}).get('columns', {})
+        cols['items'] = {
+            'anyOf': [
+                {'$ref': '#/components/schemas/IndicatorWithTimeframe'},
+                {'$ref': '#/components/schemas/IndicatorWithoutTimeframe'},
+            ]
+        }
+        if combos:
+            cols['examples'] = [combos[0]]
+        elif no_tf:
+            cols['examples'] = [no_tf[0]]
+
+    spec['x-timeframes'] = tfs
+    spec['x-fields'] = no_tf + combos
+    return spec
+
+
+def generate_spec(market: str, no_tf: List[str], with_tf: List[str], tfs: List[str]) -> Path:
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    base = yaml.safe_load(BASE_SPEC_PATH.read_text())
+    spec = build_spec(market, base, no_tf, with_tf, tfs)
+    out_path = OUTPUT_DIR / f'{market}.yaml'
+    out_path.write_text(yaml.safe_dump(spec, sort_keys=False, allow_unicode=True))
+    # validate without the non standard `functions` field
+    to_validate = copy.deepcopy(spec)
+    to_validate.pop('functions', None)
+    validate_spec(to_validate)
+    return out_path

--- a/tv_api_parser.py
+++ b/tv_api_parser.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+import requests
+
+from tradingview_screener.query import HEADERS
+
+META_URL = 'https://scanner.tradingview.com/{market}/metainfo'
+SCAN_URL = 'https://scanner.tradingview.com/{market}/scan'
+METAINFO_DIR = Path('data/metainfo')
+
+
+def fetch_metainfo(market: str) -> List[dict]:
+    """Return metainfo JSON for a market."""
+    try:
+        resp = requests.post(META_URL.format(market=market), json={}, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        path = METAINFO_DIR / f'{market}.json'
+        return json.loads(path.read_text())
+
+
+def sample_symbols(market: str) -> List[str]:
+    """Return a list of sample ticker symbols for a market."""
+    payload = {'symbols': {'query': {'types': []}}, 'columns': ['s'], 'range': [0, 1]}
+    try:
+        resp = requests.post(
+            SCAN_URL.format(market=market), json=payload, headers=HEADERS, timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return [row.get('s') for row in data.get('data', [])]
+    except Exception:
+        return []
+
+
+def group_fields(meta: List[dict]) -> Tuple[List[str], List[str], List[str]]:
+    """Return columns without timeframe, bases with timeframe and timeframes."""
+    columns = [item.get('n') for item in meta if item.get('n')]
+    no_tf = sorted({c for c in columns if '|' not in c})
+    tf_cols = [c for c in columns if '|' in c]
+    bases = sorted({c.split('|')[0] for c in tf_cols})
+    tfs = sorted({c.split('|')[1] for c in tf_cols})
+    return no_tf, bases, tfs


### PR DESCRIPTION
## Summary
- implement `market_loader.py` for fetching markets
- add `tv_api_parser.py` to read `/metainfo` data
- create `openapi_generator.py` that builds per‑market specs using `functions`
- rewrite `main.py` to orchestrate generation

## Testing
- `pytest -q`
- `python main.py > /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_684231b358d4832ca693872326664486