### PR TITLE
Fix metainfo downloads via GET

### DIFF
--- a/scripts/gpt_openapi_generator.py
+++ b/scripts/gpt_openapi_generator.py
@@ -30,7 +30,7 @@ def get_markets() -> List[str]:
 
 
 def fetch_metainfo(market: str) -> dict:
-    resp = requests.post(METAINFO_URL.format(market=market), json={}, headers=HEADERS, timeout=10)
+    resp = requests.get(METAINFO_URL.format(market=market), headers=HEADERS, timeout=10)
     resp.raise_for_status()
     return resp.json()
 

--- a/scripts/update_metainfo.py
+++ b/scripts/update_metainfo.py
@@ -17,7 +17,7 @@ def main() -> None:
     for market in markets:
         url = f'https://scanner.tradingview.com/{market}/metainfo'
         print(f'Downloading {url}')
-        resp = requests.post(url, json={}, headers=HEADERS)
+        resp = requests.get(url, headers=HEADERS)
         resp.raise_for_status()
         (METAINFO_DIR / f'{market}.json').write_text(resp.text)
 

--- a/tests/test_update_metainfo.py
+++ b/tests/test_update_metainfo.py
@@ -20,8 +20,8 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
     call_order = []
 
-    def fake_post(url, json=None, headers=None):
-        call_order.append(('post', url))
+    def fake_get(url, headers=None):
+        call_order.append(('get', url))
 
         class Resp:
             def __init__(self, text):
@@ -32,7 +32,7 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
         return Resp(f'data for {url}')
 
-    monkeypatch.setattr(update_metainfo.requests, 'post', fake_post)
+    monkeypatch.setattr(update_metainfo.requests, 'get', fake_get)
 
     def fake_run(args, check=False):
         call_order.append(('run', args))
@@ -41,7 +41,7 @@ def test_update_metainfo(monkeypatch, tmp_path):
 
     update_metainfo.main()
 
-    get_calls = [c for c in call_order if c[0] == 'post']
+    get_calls = [c for c in call_order if c[0] == 'get']
     run_calls = [c[1] for c in call_order if c[0] == 'run']
 
     assert len(get_calls) == len(markets)

--- a/tv_api_parser.py
+++ b/tv_api_parser.py
@@ -14,7 +14,7 @@ METAINFO_DIR = Path('data/metainfo')
 def fetch_metainfo(market: str) -> List[dict]:
     """Return metainfo JSON for a market."""
     try:
-        resp = requests.post(META_URL.format(market=market), json={}, headers=HEADERS, timeout=10)
+        resp = requests.get(META_URL.format(market=market), headers=HEADERS, timeout=10)
         resp.raise_for_status()
         return resp.json()
     except Exception:


### PR DESCRIPTION
## Summary
- pull metainfo with GET requests
- fix update script and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684238da8054832ca80abb480e2a1923