### PR TITLE
Refactor metainfo workflow for live spec generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,20 +1,13 @@
 from __future__ import annotations
 
-from market_loader import get_markets
-from tv_api_parser import fetch_metainfo, group_fields
-from openapi_generator import generate_spec
+from metainfo_loader import download_all
+from openapi_generator import generate_from_metainfo
 
 
 def main() -> None:
-    markets = get_markets()
+    markets = download_all()
     for market in markets:
-        try:
-            meta = fetch_metainfo(market)
-        except Exception as exc:
-            print(f'Failed to get metainfo for {market}: {exc}')
-            continue
-        no_tf, with_tf, tfs = group_fields(meta)
-        path = generate_spec(market, no_tf, with_tf, tfs)
+        path = generate_from_metainfo(market)
         print(f'Generated {path}')
 
 

--- a/metainfo_loader.py
+++ b/metainfo_loader.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+from tradingview_screener.query import HEADERS
+
+MARKETS_PATH = Path('data/markets.json')
+METAINFO_DIR = Path('data/metainfo')
+META_URL = 'https://scanner.tradingview.com/{market}/metainfo'
+
+
+def _read_markets(markets_path: Path) -> List[str]:
+    data = json.loads(markets_path.read_text())
+    return data.get('countries', []) + data.get('other', [])
+
+
+def download_all(
+    markets_path: Path | None = None,
+    output_dir: Path | None = None,
+    *,
+    session: Optional[requests.sessions.Session] = None,
+) -> List[str]:
+    """Download metainfo for all markets and return the market list."""
+    path = markets_path or MARKETS_PATH
+    out = output_dir or METAINFO_DIR
+    session = session or requests
+
+    markets = _read_markets(path)
+    out.mkdir(parents=True, exist_ok=True)
+    successful: List[str] = []
+
+    for market in markets:
+        url = META_URL.format(market=market)
+        try:
+            resp = session.get(url, headers=HEADERS)
+            resp.raise_for_status()
+        except Exception as exc:
+            logging.error('Failed to download %s: %s', url, exc)
+            continue
+
+        (out / f'{market}.json').write_text(resp.text, encoding='utf-8')
+        successful.append(market)
+
+    return successful

--- a/openapi_generator.py
+++ b/openapi_generator.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from typing import List
 
 import yaml
 from openapi_spec_validator.shortcuts import validate_spec
 
+from tv_api_parser import group_fields
+
 BASE_SPEC_PATH = Path('openapi.yaml')
 OUTPUT_DIR = Path('openapi_generated')
+METAINFO_DIR = Path('data/metainfo')
 
 
 def build_spec(
@@ -26,12 +30,31 @@ def build_spec(
             op = spec['paths'].pop(template)['post']
         spec.pop('paths', None)
 
-    parameters = (
+    qdict_schema = (
         op.get('requestBody', {})
         .get('content', {})
         .get('application/json', {})
         .get('schema', {'$ref': '#/components/schemas/QueryDict'})
     )
+
+    func_params = {'type': 'object'}
+
+    # extract subset for GPT functions
+    props = {}
+    if isinstance(qdict_schema, dict):
+        qprops = qdict_schema.get('properties', {})
+        props = {
+            'symbols': qprops.get('symbols', {}),
+            'columns': qprops.get('columns', {}),
+            'filters': qprops.get('filter', {}),
+            'sort': qprops.get('sort', {}),
+            'range': qprops.get('range', {}),
+        }
+    if props:
+        func_params['properties'] = props
+        func_params['required'] = []
+    else:
+        func_params = qdict_schema
     responses = op.get(
         'responses',
         {
@@ -48,7 +71,7 @@ def build_spec(
             'operationId': f'scan_{market}',
             'summary': op.get('summary', 'Scan TradingView market'),
             'description': op.get('description', ''),
-            'parameters': parameters,
+            'parameters': func_params,
             'responses': responses,
         }
     }
@@ -96,3 +119,11 @@ def generate_spec(market: str, no_tf: List[str], with_tf: List[str], tfs: List[s
     to_validate.pop('functions', None)
     validate_spec(to_validate)
     return out_path
+
+
+def generate_from_metainfo(market: str) -> Path:
+    """Generate OpenAPI spec for a market using stored metainfo."""
+    path = METAINFO_DIR / f"{market}.json"
+    meta = json.loads(path.read_text())
+    no_tf, with_tf, tfs = group_fields(meta)
+    return generate_spec(market, no_tf, with_tf, tfs)

--- a/scripts/update_metainfo.py
+++ b/scripts/update_metainfo.py
@@ -1,26 +1,19 @@
 import json
 import subprocess
 from pathlib import Path
+import sys
 
 import requests
 
-from tradingview_screener.query import HEADERS
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from metainfo_loader import download_all
 
 MARKETS_PATH = Path('data/markets.json')
 METAINFO_DIR = Path('data/metainfo')
 
 
 def main() -> None:
-    markets_data = json.loads(MARKETS_PATH.read_text())
-    markets = markets_data.get('countries', []) + markets_data.get('other', [])
-    METAINFO_DIR.mkdir(parents=True, exist_ok=True)
-    for market in markets:
-        url = f'https://scanner.tradingview.com/{market}/metainfo'
-        print(f'Downloading {url}')
-        resp = requests.get(url, headers=HEADERS)
-        resp.raise_for_status()
-        (METAINFO_DIR / f'{market}.json').write_text(resp.text)
-
+    download_all(markets_path=MARKETS_PATH, output_dir=METAINFO_DIR, session=requests)
     subprocess.run(['python', 'scripts/gpt_openapi_generator.py'], check=True)
 
 


### PR DESCRIPTION
## Summary
- add `metainfo_loader` module to fetch live TradingView metainfo
- update `openapi_generator` to read saved metainfo and expose `generate_from_metainfo`
- rewrite `main.py` to download metainfo first then build specs
- adjust `update_metainfo.py` to use the loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423af412ac832cb1156e60b80a84f0