### PR TITLE
Fix filter param name

### DIFF
--- a/openapi_generator.py
+++ b/openapi_generator.py
@@ -62,7 +62,7 @@ def build_spec(
         props = {
             'symbols': qprops.get('symbols', {}),
             'columns': qprops.get('columns', {}),
-            'filters': qprops.get('filter', {}),
+            'filter': qprops.get('filter', {}),
             'sort': qprops.get('sort', {}),
             'range': qprops.get('range', {}),
         }


### PR DESCRIPTION
## Summary
- rename `filters` key to `filter` in OpenAPI generator
- regenerate OpenAPI specs

## Testing
- `poetry run pytest -q`
- `poetry run python scripts/gpt_openapi_generator.py` *(fails: unable to fetch remote metainfo)*

------
https://chatgpt.com/codex/tasks/task_e_684384dfe5d4832ca84a17bb426892ff