### PR TITLE
Add script for per-market OpenAPI spec generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,14 @@ python scripts/generate_openapi.py
 
 This writes the files `specs/openapi.yaml` and `specs/bundle.yaml`.
 
+To generate minimal OpenAPI files for specific markets run:
+
+```bash
+python scripts/generate_openapi_markets.py
+```
+
+This will create files like `specs/openapi_america.yaml`.
+
 ## Feedback and Improvement
 
 If this package has bought value to your projects, please consider starring it.

--- a/scripts/generate_openapi_markets.py
+++ b/scripts/generate_openapi_markets.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import sys
+import yaml
+from fastapi.openapi.utils import get_openapi
+from tradingview_screener.openapi import create_app, ScanRequest
+
+
+def generate_for_market(market: str) -> None:
+    # patch default markets for the ScanRequest
+    ScanRequest.model_fields['markets'].default = [market]
+    app = create_app()
+    spec = get_openapi(title=f"TradingView Screener API - {market}", version="1.0.0", routes=app.routes)
+    with open(f"specs/openapi_{market}.yaml", "w") as f:
+        yaml.dump(spec, f, sort_keys=False)
+
+
+def main() -> None:
+    markets = sys.argv[1:] if len(sys.argv) > 1 else ["america", "crypto", "forex"]
+    for market in markets:
+        generate_for_market(market)
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/openapi_america.yaml
+++ b/specs/openapi_america.yaml
@@ -1,0 +1,82 @@
+openapi: 3.1.0
+info:
+  title: TradingView Screener API - america
+  version: 1.0.0
+paths:
+  /scan:
+    post:
+      summary: Scan
+      operationId: scan_scan_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ScanRequest:
+      properties:
+        markets:
+          items:
+            type: string
+          type: array
+          title: Markets
+          default:
+          - america
+        columns:
+          items:
+            type: string
+          type: array
+          title: Columns
+          default:
+          - name
+          - close
+        limit:
+          type: integer
+          title: Limit
+          default: 50
+      type: object
+      title: ScanRequest
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,0 +1,82 @@
+openapi: 3.1.0
+info:
+  title: TradingView Screener API - crypto
+  version: 1.0.0
+paths:
+  /scan:
+    post:
+      summary: Scan
+      operationId: scan_scan_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ScanRequest:
+      properties:
+        markets:
+          items:
+            type: string
+          type: array
+          title: Markets
+          default:
+          - america
+        columns:
+          items:
+            type: string
+          type: array
+          title: Columns
+          default:
+          - name
+          - close
+        limit:
+          type: integer
+          title: Limit
+          default: 50
+      type: object
+      title: ScanRequest
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/specs/openapi_forex.yaml
+++ b/specs/openapi_forex.yaml
@@ -1,0 +1,82 @@
+openapi: 3.1.0
+info:
+  title: TradingView Screener API - forex
+  version: 1.0.0
+paths:
+  /scan:
+    post:
+      summary: Scan
+      operationId: scan_scan_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ScanRequest:
+      properties:
+        markets:
+          items:
+            type: string
+          type: array
+          title: Markets
+          default:
+          - america
+        columns:
+          items:
+            type: string
+          type: array
+          title: Columns
+          default:
+          - name
+          - close
+        limit:
+          type: integer
+          title: Limit
+          default: 50
+      type: object
+      title: ScanRequest
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError


### PR DESCRIPTION
## Summary
- add `generate_openapi_markets.py` to build OpenAPI specs for several markets
- commit generated OpenAPI specs for `america`, `crypto`, and `forex`
- document how to generate per-market specs in README

## Testing
- `pytest -q`
- `openapi-spec-validator specs/openapi_america.yaml specs/openapi_crypto.yaml specs/openapi_forex.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68532bd0428c832cbea1949a1b3d7fd7