### PR TITLE
Improve OpenAPI docs with examples

### DIFF
--- a/specs/bundle.yaml
+++ b/specs/bundle.yaml
@@ -5,7 +5,10 @@ info:
 paths:
   /scan:
     post:
-      summary: Scan
+      tags:
+      - Scanner
+      summary: Run a screener scan
+      description: Query TradingView screener and return matching rows.
       operationId: scan_scan_post
       requestBody:
         content:
@@ -18,7 +21,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
         '422':
           description: Validation Error
           content:
@@ -43,22 +47,62 @@ components:
             type: string
           type: array
           title: Markets
+          description: Markets to scan, e.g. ``['america']`` or ``['crypto']``.
           default:
           - america
+          examples:
+          - - america
+          - - crypto
         columns:
           items:
             type: string
           type: array
           title: Columns
+          description: Columns to include in the response.
           default:
           - name
           - close
+          examples:
+          - - name
+            - close
+            - volume
         limit:
           type: integer
           title: Limit
+          description: Maximum number of rows to return.
           default: 50
+          examples:
+          - 10
       type: object
       title: ScanRequest
+      description: Request body for the ``/scan`` endpoint.
+    ScanResponse:
+      properties:
+        count:
+          type: integer
+          title: Count
+          description: Total number of records matching the query.
+          example: 17580
+        data:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Data
+          description: List of result rows.
+          examples:
+          - - close: 127.25
+              name: NVDA
+              ticker: NASDAQ:NVDA
+            - close: 558.7
+              name: SPY
+              ticker: AMEX:SPY
+      type: object
+      required:
+      - count
+      - data
+      title: ScanResponse
+      description: Response returned by the ``/scan`` endpoint.
     ValidationError:
       properties:
         loc:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -5,7 +5,10 @@ info:
 paths:
   /scan:
     post:
-      summary: Scan
+      tags:
+      - Scanner
+      summary: Run a screener scan
+      description: Query TradingView screener and return matching rows.
       operationId: scan_scan_post
       requestBody:
         content:
@@ -18,7 +21,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
         '422':
           description: Validation Error
           content:
@@ -43,22 +47,62 @@ components:
             type: string
           type: array
           title: Markets
+          description: Markets to scan, e.g. ``['america']`` or ``['crypto']``.
           default:
           - america
+          examples:
+          - - america
+          - - crypto
         columns:
           items:
             type: string
           type: array
           title: Columns
+          description: Columns to include in the response.
           default:
           - name
           - close
+          examples:
+          - - name
+            - close
+            - volume
         limit:
           type: integer
           title: Limit
+          description: Maximum number of rows to return.
           default: 50
+          examples:
+          - 10
       type: object
       title: ScanRequest
+      description: Request body for the ``/scan`` endpoint.
+    ScanResponse:
+      properties:
+        count:
+          type: integer
+          title: Count
+          description: Total number of records matching the query.
+          example: 17580
+        data:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Data
+          description: List of result rows.
+          examples:
+          - - close: 127.25
+              name: NVDA
+              ticker: NASDAQ:NVDA
+            - close: 558.7
+              name: SPY
+              ticker: AMEX:SPY
+      type: object
+      required:
+      - count
+      - data
+      title: ScanResponse
+      description: Response returned by the ``/scan`` endpoint.
     ValidationError:
       properties:
         loc:

--- a/specs/openapi_america.yaml
+++ b/specs/openapi_america.yaml
@@ -5,7 +5,10 @@ info:
 paths:
   /scan:
     post:
-      summary: Scan
+      tags:
+      - Scanner
+      summary: Run a screener scan
+      description: Query TradingView screener and return matching rows.
       operationId: scan_scan_post
       requestBody:
         content:
@@ -18,7 +21,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
         '422':
           description: Validation Error
           content:
@@ -43,22 +47,62 @@ components:
             type: string
           type: array
           title: Markets
+          description: Markets to scan, e.g. ``['america']`` or ``['crypto']``.
           default:
           - america
+          examples:
+          - - america
+          - - crypto
         columns:
           items:
             type: string
           type: array
           title: Columns
+          description: Columns to include in the response.
           default:
           - name
           - close
+          examples:
+          - - name
+            - close
+            - volume
         limit:
           type: integer
           title: Limit
+          description: Maximum number of rows to return.
           default: 50
+          examples:
+          - 10
       type: object
       title: ScanRequest
+      description: Request body for the ``/scan`` endpoint.
+    ScanResponse:
+      properties:
+        count:
+          type: integer
+          title: Count
+          description: Total number of records matching the query.
+          example: 17580
+        data:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Data
+          description: List of result rows.
+          examples:
+          - - close: 127.25
+              name: NVDA
+              ticker: NASDAQ:NVDA
+            - close: 558.7
+              name: SPY
+              ticker: AMEX:SPY
+      type: object
+      required:
+      - count
+      - data
+      title: ScanResponse
+      description: Response returned by the ``/scan`` endpoint.
     ValidationError:
       properties:
         loc:

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -5,7 +5,10 @@ info:
 paths:
   /scan:
     post:
-      summary: Scan
+      tags:
+      - Scanner
+      summary: Run a screener scan
+      description: Query TradingView screener and return matching rows.
       operationId: scan_scan_post
       requestBody:
         content:
@@ -18,7 +21,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
         '422':
           description: Validation Error
           content:
@@ -43,22 +47,62 @@ components:
             type: string
           type: array
           title: Markets
+          description: Markets to scan, e.g. ``['america']`` or ``['crypto']``.
           default:
           - america
+          examples:
+          - - america
+          - - crypto
         columns:
           items:
             type: string
           type: array
           title: Columns
+          description: Columns to include in the response.
           default:
           - name
           - close
+          examples:
+          - - name
+            - close
+            - volume
         limit:
           type: integer
           title: Limit
+          description: Maximum number of rows to return.
           default: 50
+          examples:
+          - 10
       type: object
       title: ScanRequest
+      description: Request body for the ``/scan`` endpoint.
+    ScanResponse:
+      properties:
+        count:
+          type: integer
+          title: Count
+          description: Total number of records matching the query.
+          example: 17580
+        data:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Data
+          description: List of result rows.
+          examples:
+          - - close: 127.25
+              name: NVDA
+              ticker: NASDAQ:NVDA
+            - close: 558.7
+              name: SPY
+              ticker: AMEX:SPY
+      type: object
+      required:
+      - count
+      - data
+      title: ScanResponse
+      description: Response returned by the ``/scan`` endpoint.
     ValidationError:
       properties:
         loc:

--- a/specs/openapi_forex.yaml
+++ b/specs/openapi_forex.yaml
@@ -5,7 +5,10 @@ info:
 paths:
   /scan:
     post:
-      summary: Scan
+      tags:
+      - Scanner
+      summary: Run a screener scan
+      description: Query TradingView screener and return matching rows.
       operationId: scan_scan_post
       requestBody:
         content:
@@ -18,7 +21,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
         '422':
           description: Validation Error
           content:
@@ -43,22 +47,62 @@ components:
             type: string
           type: array
           title: Markets
+          description: Markets to scan, e.g. ``['america']`` or ``['crypto']``.
           default:
           - america
+          examples:
+          - - america
+          - - crypto
         columns:
           items:
             type: string
           type: array
           title: Columns
+          description: Columns to include in the response.
           default:
           - name
           - close
+          examples:
+          - - name
+            - close
+            - volume
         limit:
           type: integer
           title: Limit
+          description: Maximum number of rows to return.
           default: 50
+          examples:
+          - 10
       type: object
       title: ScanRequest
+      description: Request body for the ``/scan`` endpoint.
+    ScanResponse:
+      properties:
+        count:
+          type: integer
+          title: Count
+          description: Total number of records matching the query.
+          example: 17580
+        data:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Data
+          description: List of result rows.
+          examples:
+          - - close: 127.25
+              name: NVDA
+              ticker: NASDAQ:NVDA
+            - close: 558.7
+              name: SPY
+              ticker: AMEX:SPY
+      type: object
+      required:
+      - count
+      - data
+      title: ScanResponse
+      description: Response returned by the ``/scan`` endpoint.
     ValidationError:
       properties:
         loc:

--- a/src/tradingview_screener/openapi.py
+++ b/src/tradingview_screener/openapi.py
@@ -17,31 +17,36 @@ class ScanRequest(BaseModel):
     markets: list[str] = Field(
         default=["america"],
         description="Markets to scan, e.g. ``['america']`` or ``['crypto']``.",
-        examples=[["america"], ["crypto"]],
+        json_schema_extra={"examples": [["america"], ["crypto"]]},
     )
     columns: list[str] = Field(
         default=["name", "close"],
         description="Columns to include in the response.",
-        examples=[["name", "close", "volume"]],
+        json_schema_extra={"examples": [["name", "close", "volume"]]},
     )
     limit: int = Field(
         default=50,
         description="Maximum number of rows to return.",
-        examples=[10],
+        json_schema_extra={"examples": [10]},
     )
 
 class ScanResponse(BaseModel):
     """Response returned by the ``/scan`` endpoint."""
 
-    count: int = Field(description="Total number of records matching the query.", example=17580)
+    count: int = Field(
+        description="Total number of records matching the query.",
+        json_schema_extra={"example": 17580},
+    )
     data: list[dict] = Field(
         description="List of result rows.",
-        examples=[
-            [
-                {"ticker": "NASDAQ:NVDA", "name": "NVDA", "close": 127.25},
-                {"ticker": "AMEX:SPY", "name": "SPY", "close": 558.7},
+        json_schema_extra={
+            "examples": [
+                [
+                    {"ticker": "NASDAQ:NVDA", "name": "NVDA", "close": 127.25},
+                    {"ticker": "AMEX:SPY", "name": "SPY", "close": 558.7},
+                ]
             ]
-        ],
+        },
     )
 
 @app.post(

--- a/src/tradingview_screener/openapi.py
+++ b/src/tradingview_screener/openapi.py
@@ -1,22 +1,60 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tradingview_screener.query import Query as TVQuery
 
-app = FastAPI(title="TradingView Screener API")
+app = FastAPI(
+    title="TradingView Screener API",
+    version="1.0.0",
+    description="FastAPI server exposing TradingView screener queries",
+)
 
 class ScanRequest(BaseModel):
-    markets: list[str] = ["america"]
-    columns: list[str] = ["name", "close"]
-    limit: int = 50
+    """Request body for the ``/scan`` endpoint."""
 
-@app.post("/scan")
-def scan(req: ScanRequest):
+    markets: list[str] = Field(
+        default=["america"],
+        description="Markets to scan, e.g. ``['america']`` or ``['crypto']``.",
+        examples=[["america"], ["crypto"]],
+    )
+    columns: list[str] = Field(
+        default=["name", "close"],
+        description="Columns to include in the response.",
+        examples=[["name", "close", "volume"]],
+    )
+    limit: int = Field(
+        default=50,
+        description="Maximum number of rows to return.",
+        examples=[10],
+    )
+
+class ScanResponse(BaseModel):
+    """Response returned by the ``/scan`` endpoint."""
+
+    count: int = Field(description="Total number of records matching the query.", example=17580)
+    data: list[dict] = Field(
+        description="List of result rows.",
+        examples=[
+            [
+                {"ticker": "NASDAQ:NVDA", "name": "NVDA", "close": 127.25},
+                {"ticker": "AMEX:SPY", "name": "SPY", "close": 558.7},
+            ]
+        ],
+    )
+
+@app.post(
+    "/scan",
+    summary="Run a screener scan",
+    response_model=ScanResponse,
+    tags=["Scanner"],
+)
+def scan(req: ScanRequest) -> ScanResponse:
+    """Query TradingView screener and return matching rows."""
     q = TVQuery().set_markets(*req.markets).select(*req.columns).limit(req.limit)
     count, df = q.get_scanner_data()
-    return {"count": count, "data": df.to_dict(orient="records")}
+    return ScanResponse(count=count, data=df.to_dict(orient="records"))
 
 
 def create_app() -> FastAPI:


### PR DESCRIPTION
## Summary
- document more details in the FastAPI app
- generate fresh OpenAPI specs with example values

## Testing
- `pip install -e .`
- `pytest -q`
- `python scripts/generate_openapi.py`
- `python scripts/generate_openapi_markets.py`
- `openapi-spec-validator specs/openapi.yaml`
- `openapi-spec-validator specs/bundle.yaml`
- `openapi-spec-validator specs/openapi_america.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_forex.yaml`
- `tvgen refresh --market all` *(fails: command not found)*
- `tvgen generate --market all` *(fails: command not found)*
- `tvgen validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533424d210832ca706a8bae9912e7b